### PR TITLE
Change version related index info.

### DIFF
--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Crosswalk.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Crosswalk.java
@@ -143,7 +143,8 @@ public class Crosswalk extends BaseMSCRController {
 			Model prevVersionModel = jenaService.getCrosswalk(target);
 			Resource prevVersionResource = prevVersionModel.getResource(target);
 			prevVersionResource.addProperty(MSCR.hasRevision, crosswalkResource);
-			jenaService.updateCrosswalk(target, prevVersionModel);			
+			jenaService.updateCrosswalk(target, prevVersionModel);
+			openSearchIndexer.updateSchemaToIndex(mapper.mapToIndexModel(target, prevVersionModel));
 		}
 		
 		var indexModel = mapper.mapToIndexModel(PID, jenaModel);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Schema.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/endpoint/Schema.java
@@ -337,6 +337,7 @@ public class Schema extends BaseMSCRController {
 				Resource prevVersionResource = prevVersionModel.getResource(target);
 				prevVersionResource.addProperty(MSCR.hasRevision, schemaResource);
 				jenaService.updateSchema(target, prevVersionModel);
+				openSearchIndexer.updateSchemaToIndex(mapper.mapToIndexModel(target, prevVersionModel));
 
 			}
 			var indexModel = mapper.mapToIndexModel(PID, jenaModel);

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CrosswalkMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/CrosswalkMapper.java
@@ -411,8 +411,15 @@ public class CrosswalkMapper {
     		List<Revision> orderedRevs = revs.stream()
     				.sorted((Revision r1, Revision r2) -> r1.getCreated().compareTo(r2.getCreated()))
     				.collect(Collectors.toList());
-    		indexModel.setRevisions(orderedRevs); 
-    		indexModel.setNumberOfRevisions(orderedRevs.size());	
+    		//indexModel.setRevisions(orderedRevs); 
+    		Revision latestRev = orderedRevs.get(orderedRevs.size() - 1);
+    		if(latestRev.getPid().equals(pid)) {
+    			indexModel.setHasRevision(null);
+    			indexModel.setNumberOfRevisions(orderedRevs.size());
+    		}
+    		else {
+    			indexModel.setHasRevision("true");
+    		}
         }        
         indexModel.setVersionLabel(MapperUtils.propertyToString(resource, MSCR.versionLabel));
         

--- a/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/SchemaMapper.java
+++ b/src/main/java/fi/vm/yti/datamodel/api/v2/mapper/SchemaMapper.java
@@ -219,9 +219,10 @@ public class SchemaMapper {
 		modelResource.addProperty(MSCR.namespace, ResourceFactory.createResource(dto.getNamespace()));
 		
 		if(handle != null) {
-			model.addLiteral(modelResource, MSCR.handle, model.createLiteral(handle));
-			
+			model.addLiteral(modelResource, MSCR.handle, model.createLiteral(handle));			
 		}
+		
+		
 		return model;
 	}
 
@@ -432,16 +433,25 @@ public class SchemaMapper {
         if(revisionsModel == null) {
         	revisionsModel = jenaService.constructWithQuerySchemas(MapperUtils.getRevisionsQuery(indexModel.getAggregationKey()));
         }
+
         Resource aggregationResource = resource.getPropertyResourceValue(MSCR.aggregationKey);
         if(aggregationResource != null) {
-            revisionsModel.listSubjectsWithProperty(MSCR.aggregationKey, aggregationResource) .forEach(res -> {
+            revisionsModel.listSubjects().forEach(res -> {
     			revs.add(MapperUtils.mapToRevision(res));				
     		});
     		List<Revision> orderedRevs = revs.stream()
     				.sorted((Revision r1, Revision r2) -> r1.getCreated().compareTo(r2.getCreated()))
     				.collect(Collectors.toList());
-    		indexModel.setRevisions(orderedRevs); 
-    		indexModel.setNumberOfRevisions(orderedRevs.size());	
+    		//indexModel.setRevisions(orderedRevs);     			
+    		Revision latestRev = orderedRevs.get(orderedRevs.size() - 1);
+    		if(latestRev.getPid().equals(pid)) {
+    			indexModel.setHasRevision(null);
+    			indexModel.setNumberOfRevisions(orderedRevs.size());
+    		}
+    		else {
+    			indexModel.setHasRevision("true");
+    		}
+    		
         }
         indexModel.setVersionLabel(resource.getProperty(MSCR.versionLabel).getString());
 


### PR DESCRIPTION
Removed revisions array and replaced it with a simpler hasRevision field, which is only available if content has a newer version.